### PR TITLE
Add translations for new event-related phrases in multiple languages

### DIFF
--- a/ar.js
+++ b/ar.js
@@ -1,4 +1,11 @@
 let ar = {
+  "Custom Link": "رابط مخصص",
+  "Link to event page": "رابط لصفحة الحدث",
+  "No link": "لا يوجد رابط",
+  "Attach File": "إرفاق الملف",
+  "To be announced": "سيتم الإعلان عنه",
+  "Online": "متصل",
+  "Physical": "بدني",
   "Select Categories to display events related to them, or manually choose specific events under Events": "حدد الفئات لعرض الأحداث المتعلقة بها، أو اختر أحداثًا معينة يدويًا ضمن الأحداث",
   "Automatically approve events from these addresses": "الموافقة تلقائيًا على الأحداث من هذه العناوين",
   "Approve events": "الموافقة على الأحداث",

--- a/be.js
+++ b/be.js
@@ -1,4 +1,11 @@
 let be = {
+  "Custom Link": "Карыстальніцкая спасылка",
+  "Link to event page": "Спасылка на старонку падзеі",
+  "No link": "Няма спасылкі",
+  "Attach File": "Далучыць файл",
+  "To be announced": "Будзе абвешчана",
+  "Online": "Анлайн",
+  "Physical": "фізічны",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Выберыце Катэгорыі, каб паказаць звязаныя з імі падзеі, або ўручную выберыце пэўныя падзеі ў раздзеле Падзеі",
   "Automatically approve events from these addresses": "Аўтаматычна зацвярджаць падзеі з гэтых адрасоў",
   "Approve events": "Зацвердзіць падзеі",

--- a/bg.js
+++ b/bg.js
@@ -1,4 +1,11 @@
 let bg = {
+  "Custom Link": "Персонализирана връзка",
+  "Link to event page": "Връзка към страницата на събитието",
+  "No link": "Няма връзка",
+  "Attach File": "Прикачване на файл",
+  "To be announced": "Предстои да бъде обявено",
+  "Online": "Онлайн",
+  "Physical": "Физически",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Изберете Категории, за да покажете събития, свързани с тях, или изберете ръчно конкретни събития под Събития",
   "Automatically approve events from these addresses": "Автоматично одобряване на събития от тези адреси",
   "Approve events": "Одобряване на събития",

--- a/ca.js
+++ b/ca.js
@@ -1,4 +1,11 @@
 let ca = {
+  "Custom Link": "Enllaç personalitzat",
+  "Link to event page": "Enllaç a la pàgina de l'esdeveniment",
+  "No link": "Sense enllaç",
+  "Attach File": "Adjuntar fitxer",
+  "To be announced": "A anunciar",
+  "Online": "En línia",
+  "Physical": "Física",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Seleccioneu Categories per mostrar esdeveniments relacionats amb elles, o trieu manualment esdeveniments específics a Esdeveniments",
   "Automatically approve events from these addresses": "Aprova automàticament els esdeveniments d'aquestes adreces",
   "Approve events": "Aprovar esdeveniments",

--- a/cs.js
+++ b/cs.js
@@ -1,4 +1,11 @@
 let cs = {
+  "Custom Link": "Vlastní odkaz",
+  "Link to event page": "Odkaz na stránku události",
+  "No link": "Žádný odkaz",
+  "Attach File": "Připojit soubor",
+  "To be announced": "Bude oznámeno",
+  "Online": "Online",
+  "Physical": "Fyzikální",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Vyberte Kategorie, chcete-li zobrazit události, které se k nim vztahují, nebo ručně vyberte konkrétní události v části Události",
   "Automatically approve events from these addresses": "Automaticky schvalovat události z těchto adres",
   "Approve events": "Schvalovat události",

--- a/cy.js
+++ b/cy.js
@@ -1,4 +1,11 @@
 let cy = {
+  "Custom Link": "Cyswllt Personol",
+  "Link to event page": "Dolen i dudalen digwyddiad",
+  "No link": "Dim cyswllt",
+  "Attach File": "Atodwch Ffeil",
+  "To be announced": "I'w gyhoeddi",
+  "Online": "Ar-lein",
+  "Physical": "Corfforol",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Dewiswch Categorïau i arddangos digwyddiadau sy'n gysylltiedig â nhw, neu dewiswch ddigwyddiadau penodol â llaw o dan Digwyddiadau",
   "Automatically approve events from these addresses": "Cymeradwyo digwyddiadau o'r cyfeiriadau hyn yn awtomatig",
   "Approve events": "Cymeradwyo digwyddiadau",

--- a/da.js
+++ b/da.js
@@ -1,4 +1,11 @@
 let da = {
+  "Custom Link": "Brugerdefineret link",
+  "Link to event page": "Link til begivenhedssiden",
+  "No link": "Intet link",
+  "Attach File": "Vedhæft fil",
+  "To be announced": "Skal annonceres",
+  "Online": "Online",
+  "Physical": "Fysisk",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Vælg kategorier for at vise begivenheder relateret til dem, eller vælg manuelt specifikke begivenheder under begivenheder",
   "Automatically approve events from these addresses": "Godkend automatisk begivenheder fra disse adresser",
   "Approve events": "Godkend begivenheder",

--- a/de.js
+++ b/de.js
@@ -1,4 +1,11 @@
 let de = {
+  "Custom Link": "Benutzerdefinierter Link",
+  "Link to event page": "Link zur Veranstaltungsseite",
+  "No link": "Kein Link",
+  "Attach File": "Datei anhängen",
+  "To be announced": "Wird noch bekannt gegeben",
+  "Online": "Online",
+  "Physical": "Physikalisch",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Wählen Sie „Kategorien“ aus, um damit verbundene Ereignisse anzuzeigen, oder wählen Sie unter „Ereignisse“ manuell bestimmte Ereignisse aus",
   "Automatically approve events from these addresses": "Ereignisse von diesen Adressen automatisch genehmigen",
   "Approve events": "Veranstaltungen genehmigen",

--- a/el.js
+++ b/el.js
@@ -1,4 +1,11 @@
 let el = {
+  "Custom Link": "Προσαρμοσμένος σύνδεσμος",
+  "Link to event page": "Σύνδεσμος στη σελίδα εκδήλωσης",
+  "No link": "Χωρίς σύνδεσμο",
+  "Attach File": "Επισύναψη αρχείου",
+  "To be announced": "Να ανακοινωθεί",
+  "Online": "Διαδικτυακά",
+  "Physical": "Φυσικός",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Επιλέξτε Κατηγορίες για να εμφανίσετε συμβάντα που σχετίζονται με αυτές ή επιλέξτε με μη αυτόματο τρόπο συγκεκριμένα συμβάντα στην ενότητα Εκδηλώσεις",
   "Automatically approve events from these addresses": "Αυτόματη έγκριση συμβάντων από αυτές τις διευθύνσεις",
   "Approve events": "Έγκριση συμβάντων",

--- a/en.js
+++ b/en.js
@@ -1,4 +1,11 @@
 let en = {
+  "Custom Link": "Custom Link",
+  "Link to event page": "Link to event page",
+  "No link": "No link",
+  "Attach File": "Attach File",
+  "To be announced": "To be announced",
+  "Online": "Online",
+  "Physical": "Physical",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Select Categories to display events related to them, or manually choose specific events under Events",
   "Automatically approve events from these addresses": "Automatically approve events from these addresses",
   "Approve events": "Approve events",

--- a/es.js
+++ b/es.js
@@ -1,4 +1,11 @@
 let es = {
+  "Custom Link": "Enlace personalizado",
+  "Link to event page": "Enlace a la página del evento",
+  "No link": "Sin enlace",
+  "Attach File": "Adjuntar archivo",
+  "To be announced": "Por anunciar",
+  "Online": "En línea",
+  "Physical": "Físico",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Seleccione Categorías para mostrar eventos relacionados con ellas, o elija manualmente eventos específicos en Eventos",
   "Automatically approve events from these addresses": "Aprobar automáticamente eventos de estas direcciones",
   "Approve events": "Aprobar eventos",

--- a/et.js
+++ b/et.js
@@ -1,4 +1,11 @@
 let et = {
+  "Custom Link": "Kohandatud link",
+  "Link to event page": "Link sündmuse lehele",
+  "No link": "Link puudub",
+  "Attach File": "Manusta fail",
+  "To be announced": "Tuleb välja kuulutada",
+  "Online": "Internetis",
+  "Physical": "Füüsiline",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Valige Kategooriad, et kuvada nendega seotud sündmusi, või valige sündmused käsitsi konkreetsed sündmused",
   "Automatically approve events from these addresses": "Kinnitage sündmused nendelt aadressidelt automaatselt",
   "Approve events": "Kinnitage sündmused",

--- a/eu.js
+++ b/eu.js
@@ -1,4 +1,11 @@
 let eu = {
+  "Custom Link": "Esteka pertsonalizatua",
+  "Link to event page": "Gertaeren orrirako esteka",
+  "No link": "Estekarik ez",
+  "Attach File": "Erantsi Fitxategia",
+  "To be announced": "Iragartzeko",
+  "Online": "Sarean",
+  "Physical": "Fisikoa",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Hautatu Kategoriak haiekin erlazionatutako gertaerak bistaratzeko, edo eskuz aukeratu gertaera zehatzak Gertaerak atalean",
   "Automatically approve events from these addresses": "Onartu automatikoki helbide hauetako gertaerak",
   "Approve events": "Gertaerak onartzea",

--- a/fa.js
+++ b/fa.js
@@ -1,4 +1,11 @@
 let fa = {
+  "Custom Link": "لینک سفارشی",
+  "Link to event page": "پیوند به صفحه رویداد",
+  "No link": "بدون لینک",
+  "Attach File": "فایل پیوست کنید",
+  "To be announced": "اعلام می شود",
+  "Online": "آنلاین",
+  "Physical": "فیزیکی",
   "Select Categories to display events related to them, or manually choose specific events under Events": "دسته ها را برای نمایش رویدادهای مرتبط با آنها انتخاب کنید یا به صورت دستی رویدادهای خاصی را در زیر رویدادها انتخاب کنید",
   "Automatically approve events from these addresses": "به طور خودکار رویدادها را از این آدرس ها تأیید کنید",
   "Approve events": "رویدادها را تایید کنید",

--- a/fi.js
+++ b/fi.js
@@ -1,4 +1,11 @@
 let fi = {
+  "Custom Link": "Mukautettu linkki",
+  "Link to event page": "Linkki tapahtumasivulle",
+  "No link": "Ei linkkiä",
+  "Attach File": "Liitä tiedosto",
+  "To be announced": "Ilmoitetaan",
+  "Online": "verkossa",
+  "Physical": "Fyysinen",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Valitse Luokat näyttääksesi niihin liittyvät tapahtumat tai valitse tietyt tapahtumat manuaalisesti Tapahtumat-kohdasta",
   "Automatically approve events from these addresses": "Hyväksy tapahtumat automaattisesti näistä osoitteista",
   "Approve events": "Hyväksy tapahtumat",

--- a/fr.js
+++ b/fr.js
@@ -1,4 +1,11 @@
 let fr = {
+  "Custom Link": "Lien personnalisé",
+  "Link to event page": "Lien vers la page de l'événement",
+  "No link": "Aucun lien",
+  "Attach File": "Joindre un fichier",
+  "To be announced": "À annoncer",
+  "Online": "En ligne",
+  "Physical": "Physique",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Sélectionnez Catégories pour afficher les événements qui leur sont associés ou choisissez manuellement des événements spécifiques sous Événements.",
   "Automatically approve events from these addresses": "Approuver automatiquement les événements de ces adresses",
   "Approve events": "Approuver les événements",

--- a/he.js
+++ b/he.js
@@ -1,4 +1,11 @@
 let he = {
+  "Custom Link": "קישור מותאם אישית",
+  "Link to event page": "קישור לעמוד האירוע",
+  "No link": "אין קישור",
+  "Attach File": "צרף קובץ",
+  "To be announced": "להכריז",
+  "Online": "באינטרנט",
+  "Physical": "גוּפָנִי",
   "Select Categories to display events related to them, or manually choose specific events under Events": "בחר קטגוריות כדי להציג אירועים הקשורים אליהם, או בחר ידנית אירועים ספציפיים תחת אירועים",
   "Automatically approve events from these addresses": "אשר באופן אוטומטי אירועים מכתובות אלו",
   "Approve events": "לאשר אירועים",

--- a/hi.js
+++ b/hi.js
@@ -1,4 +1,11 @@
 let hi = {
+  "Custom Link": "विशिष्ट संबंध",
+  "Link to event page": "इवेंट पेज का लिंक",
+  "No link": "कोई लिंक नहीं",
+  "Attach File": "फ़ाइल जोड़ें",
+  "To be announced": "घोषित किए जाने हेतु",
+  "Online": "ऑनलाइन",
+  "Physical": "भौतिक",
   "Select Categories to display events related to them, or manually choose specific events under Events": "उनसे संबंधित घटनाओं को प्रदर्शित करने के लिए श्रेणियों का चयन करें, या इवेंट के अंतर्गत विशिष्ट घटनाओं को मैन्युअल रूप से चुनें",
   "Automatically approve events from these addresses": "इन पतों से ईवेंट को स्वचालित रूप से स्वीकृत करें",
   "Approve events": "घटनाओं को मंजूरी दें",

--- a/hr.js
+++ b/hr.js
@@ -1,4 +1,11 @@
 let hr = {
+  "Custom Link": "Prilagođena veza",
+  "Link to event page": "Link na stranicu događaja",
+  "No link": "Nema veze",
+  "Attach File": "Priloži datoteku",
+  "To be announced": "Bit će objavljeno",
+  "Online": "Online",
+  "Physical": "Fizički",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Odaberite Kategorije za prikaz događaja povezanih s njima ili ručno odaberite određene događaje pod Događaji",
   "Automatically approve events from these addresses": "Automatski odobri događaje s ovih adresa",
   "Approve events": "Odobravanje događaja",

--- a/hu.js
+++ b/hu.js
@@ -1,4 +1,11 @@
 let hu = {
+  "Custom Link": "Egyéni link",
+  "Link to event page": "Link az esemény oldalára",
+  "No link": "Nincs link",
+  "Attach File": "Fájl csatolása",
+  "To be announced": "Be kell jelenteni",
+  "Online": "Online",
+  "Physical": "Fizikai",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Válassza a Kategóriák lehetőséget a hozzájuk kapcsolódó események megjelenítéséhez, vagy válasszon manuálisan konkrét eseményeket az Események alatt",
   "Automatically approve events from these addresses": "Események automatikus jóváhagyása ezekről a címekről",
   "Approve events": "Jóváhagyni az eseményeket",

--- a/hy.js
+++ b/hy.js
@@ -1,4 +1,11 @@
 let hy = {
+  "Custom Link": "Պատվերով հղում",
+  "Link to event page": "Հղում դեպի միջոցառման էջ",
+  "No link": "Ոչ մի հղում",
+  "Attach File": "Կցել Ֆայլը",
+  "To be announced": "Կհայտարարվի",
+  "Online": "Առցանց",
+  "Physical": "Ֆիզիկական",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Ընտրեք Կատեգորիաներ՝ դրանց հետ կապված իրադարձությունները ցուցադրելու համար, կամ ձեռքով ընտրեք կոնկրետ իրադարձություններ Իրադարձություններում",
   "Automatically approve events from these addresses": "Ավտոմատ հաստատեք իրադարձություններն այս հասցեներից",
   "Approve events": "Հաստատել իրադարձությունները",

--- a/id.js
+++ b/id.js
@@ -1,4 +1,11 @@
 let id = {
+  "Custom Link": "Tautan Kustom",
+  "Link to event page": "Tautan ke halaman acara",
+  "No link": "Tidak ada tautan",
+  "Attach File": "Lampirkan File",
+  "To be announced": "Akan diumumkan",
+  "Online": "On line",
+  "Physical": "Fisik",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Pilih Kategori untuk menampilkan acara yang terkait dengannya, atau pilih acara tertentu secara manual di bawah Acara",
   "Automatically approve events from these addresses": "Secara otomatis menyetujui acara dari alamat ini",
   "Approve events": "Menyetujui acara",

--- a/is.js
+++ b/is.js
@@ -1,4 +1,11 @@
 let is = {
+  "Custom Link": "Sérsniðinn hlekkur",
+  "Link to event page": "Tengill á viðburðarsíðu",
+  "No link": "Enginn hlekkur",
+  "Attach File": "Hengja skrá",
+  "To be announced": "Verður tilkynnt",
+  "Online": "Á netinu",
+  "Physical": "Líkamlegt",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Veldu Flokkar til að birta atburði sem tengjast þeim, eða veldu handvirkt sérstaka viðburði undir Viðburðir",
   "Automatically approve events from these addresses": "Samþykkja sjálfkrafa viðburði frá þessum netföngum",
   "Approve events": "Samþykkja viðburði",

--- a/it.js
+++ b/it.js
@@ -1,4 +1,11 @@
 let it = {
+  "Custom Link": "Collegamento personalizzato",
+  "Link to event page": "Collegamento alla pagina dell'evento",
+  "No link": "Nessun collegamento",
+  "Attach File": "Allega file",
+  "To be announced": "Da annunciare",
+  "Online": "In linea",
+  "Physical": "Fisico",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Seleziona Categorie per visualizzare gli eventi ad esse correlati oppure scegli manualmente eventi specifici in Eventi",
   "Automatically approve events from these addresses": "Approva automaticamente gli eventi da questi indirizzi",
   "Approve events": "Approvare eventi",

--- a/ja.js
+++ b/ja.js
@@ -1,4 +1,11 @@
 let ja = {
+  "Custom Link": "カスタムリンク",
+  "Link to event page": "イベントページへのリンク",
+  "No link": "リンクなし",
+  "Attach File": "ファイルを添付",
+  "To be announced": "後日発表",
+  "Online": "オンライン",
+  "Physical": "物理的な",
   "Select Categories to display events related to them, or manually choose specific events under Events": "カテゴリを選択してそれに関連するイベントを表示するか、イベントで特定のイベントを手動で選択します",
   "Automatically approve events from these addresses": "これらのアドレスからのイベントを自動的に承認します",
   "Approve events": "イベントの承認",

--- a/ka.js
+++ b/ka.js
@@ -1,4 +1,11 @@
 let ka = {
+  "Custom Link": "მორგებული ბმული",
+  "Link to event page": "ბმული ღონისძიების გვერდზე",
+  "No link": "ბმული არ არის",
+  "Attach File": "მიამაგრეთ ფაილი",
+  "To be announced": "გამოცხადდება",
+  "Online": "ონლაინ",
+  "Physical": "ფიზიკური",
   "Select Categories to display events related to them, or manually choose specific events under Events": "აირჩიეთ კატეგორიები მათთან დაკავშირებული მოვლენების საჩვენებლად, ან ხელით აირჩიეთ კონკრეტული მოვლენები მოვლენების ქვეშ",
   "Automatically approve events from these addresses": "ამ მისამართებიდან მოვლენების ავტომატურად დამტკიცება",
   "Approve events": "მოვლენების დამტკიცება",

--- a/ko.js
+++ b/ko.js
@@ -1,4 +1,11 @@
 let ko = {
+  "Custom Link": "사용자 정의 링크",
+  "Link to event page": "이벤트 페이지 링크",
+  "No link": "링크 없음",
+  "Attach File": "파일 첨부",
+  "To be announced": "발표 예정",
+  "Online": "온라인",
+  "Physical": "물리적",
   "Select Categories to display events related to them, or manually choose specific events under Events": "카테고리를 선택하여 관련 이벤트를 표시하거나 이벤트 아래에서 특정 이벤트를 수동으로 선택하세요.",
   "Automatically approve events from these addresses": "이 주소의 이벤트를 자동으로 승인합니다.",
   "Approve events": "이벤트 승인",

--- a/lt.js
+++ b/lt.js
@@ -1,4 +1,11 @@
 let lt = {
+  "Custom Link": "Tinkinta nuoroda",
+  "Link to event page": "Nuoroda į renginio puslapį",
+  "No link": "Nėra nuorodos",
+  "Attach File": "Pridėti failą",
+  "To be announced": "Bus paskelbta",
+  "Online": "Prisijungę",
+  "Physical": "Fizinis",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Pasirinkite Kategorijos, kad būtų rodomi su jomis susiję įvykiai, arba rankiniu būdu pasirinkite konkrečius įvykius dalyje Įvykiai",
   "Automatically approve events from these addresses": "Automatiškai patvirtinti įvykius iš šių adresų",
   "Approve events": "Patvirtinti įvykius",

--- a/lv.js
+++ b/lv.js
@@ -1,4 +1,11 @@
 let lv = {
+  "Custom Link": "Pielāgota saite",
+  "Link to event page": "Saite uz pasākuma lapu",
+  "No link": "Nav saites",
+  "Attach File": "Pievienot failu",
+  "To be announced": "Tiks paziņots",
+  "Online": "Tiešsaistē",
+  "Physical": "Fiziskā",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Atlasiet Kategorijas, lai parādītu ar tām saistītos notikumus, vai manuāli izvēlieties konkrētus notikumus sadaļā Notikumi",
   "Automatically approve events from these addresses": "Automātiski apstiprināt pasākumus no šīm adresēm",
   "Approve events": "Apstiprināt notikumus",

--- a/mk.js
+++ b/mk.js
@@ -1,4 +1,11 @@
 let mk = {
+  "Custom Link": "Прилагодена врска",
+  "Link to event page": "Врска до страницата за настан",
+  "No link": "Нема врска",
+  "Attach File": "Прикачи датотека",
+  "To be announced": "Да се ​​објави",
+  "Online": "Онлајн",
+  "Physical": "Физички",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Изберете Категории за прикажување настани поврзани со нив или рачно изберете конкретни настани под Настани",
   "Automatically approve events from these addresses": "Автоматски одобрувајте настани од овие адреси",
   "Approve events": "Одобри настани",

--- a/mn.js
+++ b/mn.js
@@ -1,4 +1,11 @@
 let mn = {
+  "Custom Link": "Тусгай холбоос",
+  "Link to event page": "Үйл явдлын хуудас руу холбоно уу",
+  "No link": "Холбоос байхгүй",
+  "Attach File": "Файл хавсаргах",
+  "To be announced": "Зарлах гэж байна",
+  "Online": "Онлайн",
+  "Physical": "Физик",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Тэдэнтэй холбоотой үйл явдлуудыг харуулахын тулд Ангилалуудыг сонгох эсвэл Үйл явдлын доор тодорхой үйл явдлуудыг гараар сонгоно уу",
   "Automatically approve events from these addresses": "Эдгээр хаягуудаас үйл явдлуудыг автоматаар зөвшөөрөх",
   "Approve events": "Үйл явдлыг зөвшөөрөх",

--- a/mr.js
+++ b/mr.js
@@ -1,4 +1,11 @@
 let mr = {
+  "Custom Link": "सानुकूल दुवा",
+  "Link to event page": "इव्हेंट पृष्ठाचा दुवा",
+  "No link": "लिंक नाही",
+  "Attach File": "फाइल संलग्न करा",
+  "To be announced": "जाहीर करायचे",
+  "Online": "ऑनलाइन",
+  "Physical": "शारीरिक",
   "Select Categories to display events related to them, or manually choose specific events under Events": "त्यांच्याशी संबंधित कार्यक्रम प्रदर्शित करण्यासाठी श्रेणी निवडा किंवा इव्हेंट अंतर्गत विशिष्ट इव्हेंट मॅन्युअली निवडा",
   "Automatically approve events from these addresses": "या पत्त्यांमधून इव्हेंट स्वयंचलितपणे मंजूर करा",
   "Approve events": "कार्यक्रम मंजूर करा",

--- a/ms.js
+++ b/ms.js
@@ -1,4 +1,11 @@
 let ms = {
+  "Custom Link": "Pautan Tersuai",
+  "Link to event page": "Pautan ke halaman acara",
+  "No link": "Tiada pautan",
+  "Attach File": "Lampirkan Fail",
+  "To be announced": "Akan diumumkan",
+  "Online": "dalam talian",
+  "Physical": "Fizikal",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Pilih Kategori untuk memaparkan acara yang berkaitan dengannya atau pilih acara tertentu secara manual di bawah Acara",
   "Automatically approve events from these addresses": "Luluskan acara secara automatik daripada alamat ini",
   "Approve events": "Luluskan acara",

--- a/nb.js
+++ b/nb.js
@@ -1,4 +1,11 @@
 let nb = {
+  "Custom Link": "Egendefinert kobling",
+  "Link to event page": "Link til arrangementssiden",
+  "No link": "Ingen lenke",
+  "Attach File": "Legg ved fil",
+  "To be announced": "Skal annonseres",
+  "Online": "Online",
+  "Physical": "Fysisk",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Velg kategorier for å vise hendelser relatert til dem, eller velg spesifikke hendelser manuelt under hendelser",
   "Automatically approve events from these addresses": "Godkjenn automatisk hendelser fra disse adressene",
   "Approve events": "Godkjenne arrangementer",

--- a/nl.js
+++ b/nl.js
@@ -1,4 +1,11 @@
 let nl = {
+  "Custom Link": "Aangepaste link",
+  "Link to event page": "Link naar evenementenpagina",
+  "No link": "Geen link",
+  "Attach File": "Bestand bijvoegen",
+  "To be announced": "Wordt nog bekendgemaakt",
+  "Online": "Online",
+  "Physical": "Fysiek",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Selecteer Categorieën om gebeurtenissen weer te geven die daaraan gerelateerd zijn, of kies handmatig specifieke gebeurtenissen onder Gebeurtenissen",
   "Automatically approve events from these addresses": "Keur automatisch evenementen van deze adressen goed",
   "Approve events": "Evenementen goedkeuren",

--- a/no.js
+++ b/no.js
@@ -1,4 +1,11 @@
 let no = {
+  "Custom Link": "Egendefinert kobling",
+  "Link to event page": "Link til arrangementssiden",
+  "No link": "Ingen lenke",
+  "Attach File": "Legg ved fil",
+  "To be announced": "Skal annonseres",
+  "Online": "Online",
+  "Physical": "Fysisk",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Velg kategorier for å vise hendelser relatert til dem, eller velg spesifikke hendelser manuelt under hendelser",
   "Automatically approve events from these addresses": "Godkjenn automatisk hendelser fra disse adressene",
   "Approve events": "Godkjenne arrangementer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translations",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "",
   "main": "en.js",
   "scripts": {

--- a/pl.js
+++ b/pl.js
@@ -1,4 +1,11 @@
 let pl = {
+  "Custom Link": "Niestandardowy link",
+  "Link to event page": "Link do strony wydarzenia",
+  "No link": "Brak linku",
+  "Attach File": "Dołącz plik",
+  "To be announced": "Do ogłoszenia",
+  "Online": "W sieci",
+  "Physical": "Fizyczny",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Wybierz Kategorie, aby wyświetlić powiązane z nimi zdarzenia, lub ręcznie wybierz określone zdarzenia w obszarze Zdarzenia",
   "Automatically approve events from these addresses": "Automatycznie zatwierdzaj wydarzenia z tych adresów",
   "Approve events": "Zatwierdź wydarzenia",

--- a/pt.js
+++ b/pt.js
@@ -1,4 +1,11 @@
 let pt = {
+  "Custom Link": "Link personalizado",
+  "Link to event page": "Link para a página do evento",
+  "No link": "Nenhum link",
+  "Attach File": "Anexar arquivo",
+  "To be announced": "A ser anunciado",
+  "Online": "On-line",
+  "Physical": "Físico",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Selecione Categorias para exibir eventos relacionados a elas ou escolha manualmente eventos específicos em Eventos",
   "Automatically approve events from these addresses": "Aprovar automaticamente eventos destes endereços",
   "Approve events": "Aprovar eventos",

--- a/ro.js
+++ b/ro.js
@@ -1,4 +1,11 @@
 let ro = {
+  "Custom Link": "Link personalizat",
+  "Link to event page": "Link către pagina evenimentului",
+  "No link": "Niciun link",
+  "Attach File": "Atașați fișierul",
+  "To be announced": "De anunțat",
+  "Online": "Online",
+  "Physical": "Fizic",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Selectați Categorii pentru a afișa evenimente legate de acestea sau alegeți manual anumite evenimente din Evenimente",
   "Automatically approve events from these addresses": "Aprobați automat evenimentele de la aceste adrese",
   "Approve events": "Aprobați evenimente",

--- a/ru.js
+++ b/ru.js
@@ -1,4 +1,11 @@
 let ru = {
+  "Custom Link": "Пользовательская ссылка",
+  "Link to event page": "Ссылка на страницу мероприятия",
+  "No link": "Нет ссылки",
+  "Attach File": "Прикрепить файл",
+  "To be announced": "Будет объявлено дополнительно",
+  "Online": "Онлайн",
+  "Physical": "Физический",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Выберите «Категории», чтобы отобразить связанные с ними события, или вручную выберите конкретные события в разделе «События».",
   "Automatically approve events from these addresses":
     "Автоматически утверждать события с этих адресов",

--- a/sk.js
+++ b/sk.js
@@ -1,4 +1,11 @@
 let sk = {
+  "Custom Link": "Vlastný odkaz",
+  "Link to event page": "Odkaz na stránku udalosti",
+  "No link": "Žiadny odkaz",
+  "Attach File": "Pripojiť súbor",
+  "To be announced": "Bude oznámené",
+  "Online": "Online",
+  "Physical": "Fyzické",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Vyberte Kategórie, ak chcete zobraziť udalosti, ktoré s nimi súvisia, alebo manuálne vyberte konkrétne udalosti v časti Udalosti",
   "Automatically approve events from these addresses": "Automaticky schvaľovať udalosti z týchto adries",
   "Approve events": "Schvaľujte udalosti",

--- a/sq.js
+++ b/sq.js
@@ -1,4 +1,11 @@
 let sq = {
+  "Custom Link": "Lidhje e personalizuar",
+  "Link to event page": "Lidhja me faqen e ngjarjes",
+  "No link": "Asnjë lidhje",
+  "Attach File": "Bashkangjit skedarin",
+  "To be announced": "Për tu shpallur",
+  "Online": "Online",
+  "Physical": "Fizike",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Zgjidhni Kategoritë për të shfaqur ngjarje që lidhen me to, ose zgjidhni manualisht ngjarje specifike nën Ngjarjet",
   "Automatically approve events from these addresses": "Mirato automatikisht ngjarjet nga këto adresa",
   "Approve events": "Miratoni ngjarjet",

--- a/sr.js
+++ b/sr.js
@@ -1,4 +1,11 @@
 let sr = {
+  "Custom Link": "Цустом Линк",
+  "Link to event page": "Линк до странице догађаја",
+  "No link": "Нема везе",
+  "Attach File": "Приложите датотеку",
+  "To be announced": "Биће објављено",
+  "Online": "Онлине",
+  "Physical": "Физички",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Изаберите Категорије да бисте приказали догађаје у вези са њима или ручно изаберите одређене догађаје у оквиру Догађаји",
   "Automatically approve events from these addresses": "Аутоматски одобри догађаје са ових адреса",
   "Approve events": "Одобравање догађаја",

--- a/sv.js
+++ b/sv.js
@@ -1,4 +1,11 @@
 let sv = {
+  "Custom Link": "Anpassad länk",
+  "Link to event page": "Länk till eventsidan",
+  "No link": "Ingen länk",
+  "Attach File": "Bifoga fil",
+  "To be announced": "Ska meddelas",
+  "Online": "Online",
+  "Physical": "Fysisk",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Välj Kategorier för att visa händelser relaterade till dem, eller välj manuellt specifika händelser under Händelser",
   "Automatically approve events from these addresses": "Godkänn automatiskt händelser från dessa adresser",
   "Approve events": "Godkänn evenemang",

--- a/th.js
+++ b/th.js
@@ -1,4 +1,11 @@
 let th = {
+  "Custom Link": "ลิงค์ที่กำหนดเอง",
+  "Link to event page": "ลิงค์ไปยังหน้ากิจกรรม",
+  "No link": "ไม่มีลิงค์",
+  "Attach File": "แนบไฟล์",
+  "To be announced": "จะแจ้งให้ทราบต่อไป",
+  "Online": "ออนไลน์",
+  "Physical": "ทางกายภาพ",
   "Select Categories to display events related to them, or manually choose specific events under Events": "เลือกหมวดหมู่เพื่อแสดงเหตุการณ์ที่เกี่ยวข้อง หรือเลือกเหตุการณ์เฉพาะด้วยตนเองภายใต้เหตุการณ์",
   "Automatically approve events from these addresses":
     "อนุมัติกิจกรรมจากที่อยู่เหล่านี้โดยอัตโนมัติ",

--- a/tl.js
+++ b/tl.js
@@ -1,4 +1,11 @@
 let tl = {
+  "Custom Link": "Custom na Link",
+  "Link to event page": "Link sa page ng event",
+  "No link": "Walang link",
+  "Attach File": "Mag-attach ng File",
+  "To be announced": "Upang ipahayag",
+  "Online": "Online",
+  "Physical": "Pisikal",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Piliin ang Mga Kategorya upang ipakita ang mga kaganapang nauugnay sa kanila, o manu-manong pumili ng mga partikular na kaganapan sa ilalim ng Mga Kaganapan",
   "Automatically approve events from these addresses": "Awtomatikong aprubahan ang mga kaganapan mula sa mga address na ito",
   "Approve events": "Aprubahan ang mga kaganapan",

--- a/tr.js
+++ b/tr.js
@@ -1,4 +1,11 @@
 let tr = {
+  "Custom Link": "Özel Bağlantı",
+  "Link to event page": "Etkinlik sayfasına bağlantı",
+  "No link": "Bağlantı yok",
+  "Attach File": "Dosya Ekle",
+  "To be announced": "Duyurulacak",
+  "Online": "Çevrimiçi",
+  "Physical": "Fiziksel",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Kendileriyle ilgili etkinlikleri görüntülemek için Kategoriler'i seçin veya Etkinlikler altında belirli etkinlikleri manuel olarak seçin.",
   "Automatically approve events from these addresses": "Bu adreslerden gelen etkinlikleri otomatik olarak onayla",
   "Approve events": "Etkinlikleri onayla",

--- a/uk.js
+++ b/uk.js
@@ -1,4 +1,11 @@
 let uk = {
+  "Custom Link": "Спеціальне посилання",
+  "Link to event page": "Посилання на сторінку події",
+  "No link": "Немає посилання",
+  "Attach File": "Прикріпити файл",
+  "To be announced": "Буде оголошено",
+  "Online": "Онлайн",
+  "Physical": "фізичний",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Виберіть «Категорії», щоб відобразити пов’язані з ними події, або вручну виберіть певні події в розділі «Події».",
   "Automatically approve events from these addresses": "Автоматично затверджувати події з цих адрес",
   "Approve events": "Затвердити заходи",

--- a/vi.js
+++ b/vi.js
@@ -1,4 +1,11 @@
 let vi = {
+  "Custom Link": "Liên kết tùy chỉnh",
+  "Link to event page": "Liên kết đến trang sự kiện",
+  "No link": "Không có liên kết",
+  "Attach File": "Đính kèm tập tin",
+  "To be announced": "Sẽ được công bố",
+  "Online": "Trực tuyến",
+  "Physical": "Thuộc vật chất",
   "Select Categories to display events related to them, or manually choose specific events under Events": "Chọn Danh mục để hiển thị các sự kiện liên quan đến chúng hoặc chọn thủ công các sự kiện cụ thể trong Sự kiện",
   "Automatically approve events from these addresses": "Tự động phê duyệt sự kiện từ các địa chỉ này",
   "Approve events": "Phê duyệt sự kiện",

--- a/zh.js
+++ b/zh.js
@@ -1,4 +1,11 @@
 let zh = {
+  "Custom Link": "自定义链接",
+  "Link to event page": "活动页面链接",
+  "No link": "没有链接",
+  "Attach File": "附加文件",
+  "To be announced": "待公布",
+  "Online": "在线的",
+  "Physical": "身体的",
   "Select Categories to display events related to them, or manually choose specific events under Events": "选择类别以显示与其相关的事件，或在事件下手动选择特定事件",
   "Automatically approve events from these addresses": "自动批准来自这些地址的事件",
   "Approve events": "批准活动",


### PR DESCRIPTION
- Added translations for "Custom Link", "Link to event page", "No link", "Attach File", "To be announced", "Online", and "Physical" in various language files including ca.js, cs.js, cy.js, da.js, de.js, el.js, en.js, es.js, et.js, eu.js, fa.js, fi.js, fr.js, he.js, hi.js, hr.js, hu.js, hy.js, id.js, is.js, it.js, ja.js, ka.js, ko.js, lt.js, lv.js, mk.js, mn.js, mr.js, ms.js, nb.js, nl.js, no.js, pl.js, pt.js, ro.js, ru.js, sk.js, sq.js, sr.js, sv.js, th.js, tl.js, tr.js, uk.js, vi.js, and zh.js.
- Updated package version to 3.1.5 in package.json.